### PR TITLE
DHT Store 

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -14,9 +14,10 @@ func main() {
 	budget := flag.Int64("budget", 0, "budget to be used for a search")
 	node := flag.String("lookupNode", "", "request a dht node lookup")
 	key := flag.String("lookupKey", "", "request a dht key lookup")
+	store := flag.String("store", "", "key value pair of the form key:value to be stored in the dht. Value can either be a value or a url to a resource on the local file system.")
 
 	flag.Parse()
 
-	client := NewClient(*UIPort, *dest, *fileName, *msg, *request, *keywords, uint64(*budget), *node, *key)
+	client := NewClient(*UIPort, *dest, *fileName, *msg, *request, *keywords, uint64(*budget), *node, *key, *store)
 	client.sendUDP()
 }

--- a/dht/helpers.go
+++ b/dht/helpers.go
@@ -2,6 +2,8 @@ package dht
 
 import (
 	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"math/bits"
 )
@@ -101,4 +103,12 @@ func ConvertToTypeID(idB []byte) (id TypeID, ok bool) {
 	}
 	copy(id[:], idB)
 	return id, true
+}
+
+// Converts an arbitrary long key string to a 20byte hexa hash key.
+func GenerateKeyHash(key string) string {
+	byteKey := []byte(key)
+	hash := sha1.Sum(byteKey)
+	key = hex.EncodeToString(hash[:])
+	return key
 }

--- a/dht/nodeState.go
+++ b/dht/nodeState.go
@@ -56,6 +56,7 @@ func (msg *Message) GetUnderlyingType() string {
 
 type Store struct {
 	Key  TypeID
+	Type string // PUT or POST
 	Data []byte
 }
 

--- a/dht/storageMap.go
+++ b/dht/storageMap.go
@@ -1,6 +1,8 @@
 package dht
 
 import (
+	"fmt"
+	"protobuf"
 	"sync"
 )
 
@@ -33,4 +35,68 @@ func (sm *StorageMap) Retrieve(key TypeID) (data []byte, ok bool) {
 	}
 	data = d.([]byte)
 	return
+}
+
+// Special store operation for keyword -> url mappings
+// We need this extra function since we want to support PUT operations. It might not be the cleanest solution to wrap
+// the keywords and URLs in struct but I could not think about any other way.
+// The definiton of KeywordToURLMap will move to the webcrawler package but it is in a seperate branch at the moment. I will move this when
+// I merge the two branches.
+
+type KeywordToURLMap struct {
+	Keyword string
+	Urls    map[string]int // websiteUrl:NumberOfOccurances
+}
+
+func (sm *StorageMap) StoreKeywordToURLMapping(key TypeID, data []byte) (ok bool) {
+
+	newKeywordToUrlMap := &KeywordToURLMap{}
+	err := protobuf.Decode(data, newKeywordToUrlMap)
+	if err != nil {
+		fmt.Println("Error, trying to save non KeyWordToURLMapping data type.")
+		return false
+	}
+
+	dat, found := sm.ByteMap.Load(key)
+	if !found {
+		// Append to an empty key -> Store
+		sm.ByteMap.Store(key, data)
+		return true
+	}
+
+	oldKeywordToUrlMap := &KeywordToURLMap{}
+	err = protobuf.Decode(dat.([]byte), oldKeywordToUrlMap)
+	if err != nil {
+		fmt.Println("Error, trying to decode old KeywordToURLMap struct.")
+		return false
+	}
+
+	// Make sure that that the keywords correspond, they should but just to make sure.
+
+	if oldKeywordToUrlMap.Keyword != newKeywordToUrlMap.Keyword {
+		fmt.Println("Error, Keywords does not correspond.")
+		return false
+	}
+
+	// Append new urls to old struct
+	for k, _ := range newKeywordToUrlMap.Urls {
+		val, found := oldKeywordToUrlMap.Urls[k]
+		if found {
+			oldKeywordToUrlMap.Urls[k] = val + 1
+			continue
+		}
+		oldKeywordToUrlMap.Urls[k] = 1
+	}
+
+	//oldKeywordToUrlMap.Urls = append(oldKeywordToUrlMap.Urls, newKeywordToUrlMap.Urls...)
+
+	newData, err := protobuf.Encode(oldKeywordToUrlMap)
+	if err != nil {
+		fmt.Println("error trying to encode KeywordToURLMapping struct.")
+		return false
+	}
+
+	sm.ByteMap.Store(key, newData)
+
+	return true
 }

--- a/dto/DTO.go
+++ b/dto/DTO.go
@@ -851,6 +851,17 @@ type DHTLookup struct {
 	Key  *dht.TypeID
 }
 
+type DHTStore struct {
+	Key   *dht.TypeID
+	Type  string
+	Value []byte
+}
+
+type DHTRequest struct {
+	Store  *DHTStore
+	Lookup *DHTLookup
+}
+
 //ClientRequest - protocol structure to be serialized and sent from client to gossiper
 type ClientRequest struct {
 	Packet       *GossipPacket
@@ -858,6 +869,7 @@ type ClientRequest struct {
 	FileDownload *FileToDownload
 	FileSearch   *FileToSearch
 	DHTLookup    *DHTLookup
+	DHTStore     *DHTStore
 }
 
 //GetUnderlyingType - returns the underlying type of the client request, or the empty string in case of no subtype
@@ -874,6 +886,8 @@ func (cr *ClientRequest) GetUnderlyingType() (subtype string) {
 		subtype = "nodeSearch"
 	} else if cr.DHTLookup != nil && cr.DHTLookup.Key != nil {
 		subtype = "keySearch"
+	} else if cr.DHTStore != nil {
+		subtype = "store"
 	} else {
 		fmt.Printf("%v", cr)
 		subtype = ""

--- a/gossiper/dht.go
+++ b/gossiper/dht.go
@@ -254,7 +254,7 @@ func (g *Gossiper) clientDHTListenRoutine(cCliDHT chan *dto.DHTRequest) {
 				// Seperate printing function for lookups containing KeywordToURLMap structs
 				newKeywordToUrlMap := &dht.KeywordToURLMap{}
 				err := protobuf.Decode(data, newKeywordToUrlMap)
-				if err == nil {
+				if err == nil && found {
 					fmt.Printf("Keyword: %s\n", newKeywordToUrlMap.Keyword)
 					for k, v := range newKeywordToUrlMap.Urls {
 						fmt.Printf("document: %s, number of occurances in document: %d\n", k, v)

--- a/gossiper/gossiper.go
+++ b/gossiper/gossiper.go
@@ -159,7 +159,7 @@ func (g *Gossiper) Start() {
 	cFileSearch := make(chan *dto.FileToSearch)
 	go g.clientFileSearchListenRoutine(cFileSearch)
 
-	cCliDHT := make(chan *dto.DHTLookup, 10)
+	cCliDHT := make(chan *dto.DHTRequest, 10)
 	go g.clientDHTListenRoutine(cCliDHT)
 
 	if g.dhtBootstrap != "" {
@@ -205,7 +205,7 @@ func (g *Gossiper) sendStatusPacket(peerAddress string) {
 
 //receiveClientUDP - receives gossip packets from CLIENTS and forwards them to the provided channel,
 //setting the origin in the process
-func (g *Gossiper) receiveClientUDP(cRumoring, cPMing chan *dto.PacketAddressPair, cFileShare chan string, cFileDL chan *dto.FileToDownload, cFileSearch chan *dto.FileToSearch, cCliDHT chan *dto.DHTLookup) {
+func (g *Gossiper) receiveClientUDP(cRumoring, cPMing chan *dto.PacketAddressPair, cFileShare chan string, cFileDL chan *dto.FileToDownload, cFileSearch chan *dto.FileToSearch, cCliDHT chan *dto.DHTRequest) {
 	for {
 		request := &dto.ClientRequest{}
 		packetBytes := make([]byte, packetSize)
@@ -249,10 +249,22 @@ func (g *Gossiper) receiveClientUDP(cRumoring, cPMing chan *dto.PacketAddressPai
 			cFileSearch <- request.FileSearch
 		case "nodeSearch":
 			fmt.Printf("Received client lookup request\n")
-			cCliDHT <- request.DHTLookup
+			dhtRequest := &dto.DHTRequest{
+				Lookup: request.DHTLookup,
+			}
+			cCliDHT <- dhtRequest
 		case "keySearch":
 			fmt.Printf("Received client lookup request\n")
-			cCliDHT <- request.DHTLookup
+			dhtRequest := &dto.DHTRequest{
+				Lookup: request.DHTLookup,
+			}
+			cCliDHT <- dhtRequest
+		case "store":
+			fmt.Printf("Received client dht store request\n")
+			dhtRequest := &dto.DHTRequest{
+				Store: request.DHTStore,
+			}
+			cCliDHT <- dhtRequest
 		default:
 			log.Println("Unrecognized message type. Ignoring...")
 		}


### PR DESCRIPTION
- Added store functionality to peerster client
- Added store support for the peerster nodes
- Added special append store operation for (keyword->url) mappings.

I also created a wrapper object for DHTStore and DHTLookup structs called DHTRequest. I did this in order to be able to both listen for DHTLookups and stores in the clientDHTListenRoutine function. Maybe you would prefer to create a seperate go routine for listening on store requests, if so please let me know :) 